### PR TITLE
Use new validate_recaptcha routine when validating forgot password

### DIFF
--- a/source/templates/user/forgot_password.etml
+++ b/source/templates/user/forgot_password.etml
@@ -38,20 +38,10 @@
 			</td>
 		</tr>
 		<tr>
-			<th>Captcha:</th>
+			<th>&nbsp;</th>
 			<td>
-				<script type="text/javascript"
-				   src="http://api.recaptcha.net/challenge?k=<%= @re_public_key %>">
-				</script>
-
-				<noscript>
-				   <iframe src="http://api.recaptcha.net/noscript?k=<%= @re_public_key %>"
-				       height="300" width="500" frameborder="0"></iframe><br>
-				   <textarea name="recaptcha_challenge_field" rows="3" cols="40">
-				   </textarea>
-				   <input type="hidden" name="recaptcha_response_field" 
-				       value="manual_challenge">
-				</noscript>
+				<div class="g-recaptcha" data-sitekey="<%= @re_public_key %>"></div>
+				<script src="https://www.google.com/recaptcha/api.js"></script>
 			</td>
 		</tr>
 		<tr>


### PR DESCRIPTION
It still used reCATPCHAv1 that's deprectated besides loading it using HTTP
instead of HTTPs